### PR TITLE
Fix docker start.sh script

### DIFF
--- a/docker/docker-py2-kms/start.sh
+++ b/docker/docker-py2-kms/start.sh
@@ -6,15 +6,15 @@ if [ "$SQLITE" == false ];
 then
   if [ "$EPID" == "" ];
   then
-    /usr/bin/python pykms_Server.py ${IP} ${PORT} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -w ${HWID} -v ${LOGLEVEL} -f ${LOGFILE}
+    /usr/bin/python pykms_Server.py ${IP} ${PORT} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -w ${HWID} -V ${LOGLEVEL} -F ${LOGFILE}
   else
-    /usr/bin/python pykms_Server.py ${IP} ${PORT} -e ${EPID} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s ${SQLITE} -w ${HWID} -v ${LOGLEVEL} -f ${LOGFILE}
+    /usr/bin/python pykms_Server.py ${IP} ${PORT} -e ${EPID} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s ${SQLITE} -w ${HWID} -V ${LOGLEVEL} -F ${LOGFILE}
   fi
 else
   if [ "$EPID" == "" ];
   then
-    /bin/bash -c "/usr/bin/python pykms_Server.py ${IP} ${PORT} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s -w ${HWID} -v ${LOGLEVEL} -f ${LOGFILE} &" && /usr/bin/python client.py ${IP} ${PORT} -m Windows10 && /usr/bin/python /home/sqlite_web/sqlite_web.py -H ${IP} -x ${PWD}/clients.db
+    /bin/bash -c "/usr/bin/python pykms_Server.py ${IP} ${PORT} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s -w ${HWID} -V ${LOGLEVEL} -F ${LOGFILE} &" && /usr/bin/python client.py ${IP} ${PORT} -m Windows10 && /usr/bin/python /home/sqlite_web/sqlite_web.py -H ${IP} -x ${PWD}/clients.db
   else
-    /bin/bash -c "/usr/bin/python pykms_Server.py ${IP} ${PORT} -e ${EPID} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s -w ${HWID} -v ${LOGLEVEL} -f ${LOGFILE} &" && /usr/bin/python client.py ${IP} ${PORT} -m Windows10 && /usr/bin/python /home/sqlite_web/sqlite_web.py -H ${IP} -x ${PWD}/clients.db
+    /bin/bash -c "/usr/bin/python pykms_Server.py ${IP} ${PORT} -e ${EPID} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s -w ${HWID} -V ${LOGLEVEL} -F ${LOGFILE} &" && /usr/bin/python client.py ${IP} ${PORT} -m Windows10 && /usr/bin/python /home/sqlite_web/sqlite_web.py -H ${IP} -x ${PWD}/clients.db
   fi
 fi

--- a/docker/docker-py3-kms/start.sh
+++ b/docker/docker-py3-kms/start.sh
@@ -6,15 +6,15 @@ if [ "$SQLITE" == false ];
 then
   if [ "$EPID" == "" ];
   then
-    /usr/bin/python3 pykms_Server.py ${IP} ${PORT} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -w ${HWID} -v ${LOGLEVEL} -f ${LOGFILE}
+    /usr/bin/python3 pykms_Server.py ${IP} ${PORT} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -w ${HWID} -V ${LOGLEVEL} -F ${LOGFILE}
   else
-    /usr/bin/python3 pykms_Server.py ${IP} ${PORT} -e ${EPID} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s ${SQLITE} -w ${HWID} -v ${LOGLEVEL} -f ${LOGFILE}
+    /usr/bin/python3 pykms_Server.py ${IP} ${PORT} -e ${EPID} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s ${SQLITE} -w ${HWID} -V ${LOGLEVEL} -F ${LOGFILE}
   fi
 else
   if [ "$EPID" == "" ];
   then
-    /bin/bash -c "/usr/bin/python3 pykms_Server.py ${IP} ${PORT} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s -w ${HWID} -v ${LOGLEVEL} -f ${LOGFILE} &" && /usr/bin/python3 pykms_Client.py ${IP} ${PORT} -m Windows10 && /usr/bin/python3 /home/sqlite_web/sqlite_web.py -H ${IP} -x ${PWD}/clients.db --read-only
+    /bin/bash -c "/usr/bin/python3 pykms_Server.py ${IP} ${PORT} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s -w ${HWID} -V ${LOGLEVEL} -F ${LOGFILE} &" && /usr/bin/python3 pykms_Client.py ${IP} ${PORT} -m Windows10 && /usr/bin/python3 /home/sqlite_web/sqlite_web.py -H ${IP} -x ${PWD}/clients.db --read-only
   else
-    /bin/bash -c "/usr/bin/python3 pykms_Server.py ${IP} ${PORT} -e ${EPID} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s -w ${HWID} -v ${LOGLEVEL} -f ${LOGFILE} &" && /usr/bin/python3 pykms_Client.py ${IP} ${PORT} -m Windows10 && /usr/bin/python3 /home/sqlite_web/sqlite_web.py -H ${IP} -x ${PWD}/clients.db --read-only
+    /bin/bash -c "/usr/bin/python3 pykms_Server.py ${IP} ${PORT} -e ${EPID} -l ${LCID} -c ${CLIENT_COUNT} -a ${ACTIVATION_INTERVAL} -r ${RENEWAL_INTERVAL} -s -w ${HWID} -V ${LOGLEVEL} -F ${LOGFILE} &" && /usr/bin/python3 pykms_Client.py ${IP} ${PORT} -m Windows10 && /usr/bin/python3 /home/sqlite_web/sqlite_web.py -H ${IP} -x ${PWD}/clients.db --read-only
   fi
 fi


### PR DESCRIPTION
```
docker-compose logs
Attaching to kms
kms    | usage: pykms_Server.py [-h] [-e EPID] [-l LCID] [-c CURRENTCLIENTCOUNT]
kms    |                        [-a VLACTIVATIONINTERVAL] [-r VLRENEWALINTERVAL] [-s]
kms    |                        [-w HWID] [-t TIMEOUT]
kms    |                        [-V {CRITICAL,ERROR,WARNING,INFO,DEBUG,MINI}]
kms    |                        [-F LOGFILE] [-S LOGSIZE]
kms    |                        [ip] [port]
kms    | pykms_Server.py: error: unrecognized arguments: -f /var/log/pykms_logserver.log
```

The parameters have been changed from `-v` to `-V` and `-f` to `-F`

This PR fixes the start.sh scripts for the docker containers