### PR TITLE
Fix 0x stripping from HWID

### DIFF
--- a/py-kms/pykms_Server.py
+++ b/py-kms/pykms_Server.py
@@ -326,7 +326,11 @@ def server_check():
                 srv_config['hwid'] = randomhwid[:16]
            
         # Sanitize HWID.
-        hexstr = srv_config['hwid'].strip('0x')
+        hexstr = srv_config['hwid']
+        # Strip 0x from the start of hexstr
+        if hexstr.startswith("0x"):
+            hexstr = hexstr[2:]
+
         hexsub = re.sub(r'[^0-9a-fA-F]', '', hexstr)
         diff = set(hexstr).symmetric_difference(set(hexsub))
 


### PR DESCRIPTION
`str.strip(string)` removes all characters contained in the string given to it. This is not the intended behavior, and is a bug previously reported on #52.

```
>>> "046cf1cff2b9475f".strip("0x")
'46cf1cff2b9475f'
```

See https://docs.python.org/3.8/library/stdtypes.html#str.strip

I've switched to checking if the string starts with it, and simply removing it if so. Alternatively `.strip('0x')` could be replaced with `.replace('0x', '')`, however that would be less clean.