### PR TITLE
Add Python 3.10 compat

### DIFF
--- a/py-kms/Etrigan.py
+++ b/py-kms/Etrigan.py
@@ -9,7 +9,12 @@ import time
 import signal
 import logging
 import argparse
-from collections import Sequence
+
+#Since Python 3.10: Sequence is located on "collections.abc" instead of "collections"
+if (sys.version_info >= (3,10)):
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
 
 __version__             = "0.1"
 __license__             = "MIT License"


### PR DESCRIPTION
Python 3.10 changes the location of Sequence into "collections.abc"